### PR TITLE
Respond on socket and use print as fallback

### DIFF
--- a/b5/ninja_port.py
+++ b/b5/ninja_port.py
@@ -14,6 +14,10 @@ if __name__ == "__main__":
         data.rstrip()
         data.lower()
         if SECRET_GREETING in str(data).lower():
-            print("Aw man how did you know I was hiding on port {0}".format(port_num))
+            winner = "Aw man how did you know I was hiding on port {0}\n".format(port_num)
+            try:
+                connection.sendall(winner.encode())
+            except:
+                print(winner.strip())
             break;
     greeting_socket.close()


### PR DESCRIPTION
I remember really enjoying this exercise last semester but wished the response message was to the socket. I assume most students will create the connection using telnet or netcat so the connection should stay open for a response. In case the connection terminates before the response is fully sent the old print statement is used as fallback.