### PR TITLE
Update nginx-lab9.conf

### DIFF
--- a/a9/nginx-lab9.conf
+++ b/a9/nginx-lab9.conf
@@ -15,7 +15,6 @@ server {
 #  ssl_certificate <FIXME>;
 #  ssl_certificate_key <FIXME>;
 
-  include snippets/ssl-params.conf;
   charset UTF-8;
 
   root /var/www/html;


### PR DESCRIPTION
While helping debug a9 this came up as a something that doesnt exist anymore, we should delete it, baring it has no more use anymore.